### PR TITLE
WIP: Upgrade clang_variant to the version root-feedstock is using

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -82,4 +82,4 @@ jobs:
     displayName: Upload package
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
-    condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))
+    condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 # The first three items of version define the version of ROOT that we're building from.
 {% set version = "6.18.2.6" %}
 {% set clang_version = "5.0.0" %}
-{% set clang_patches_version = "6.16.00" %}
+{% set clang_patches_version = "root_20191220" %}
 
 package:
   name: {{ name }}
@@ -15,7 +15,7 @@ source:
     - use-dumb-setup.py.patch
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win]
 
 requirements:
@@ -28,7 +28,7 @@ requirements:
     - pip
     - zlib
     - clangdev ={{ clang_version }}
-    - clang_variant * cling_{{ clang_patches_version }}
+    - clang_variant * {{ clang_patches_version }}
     - llvmdev ==5
   run:
     - {{ compiler('cxx') }}


### PR DESCRIPTION
I want to see whether this fixes https://bitbucket.org/wlav/cppyy/issues/201/scope-of-static-variables-in-conda-forge

Locally, this build now segfaults for me unfortunately (during the
conda-build.)