### PR TITLE
Use an environment variable that is also available in the runtime environment

### DIFF
--- a/recipe/0011-Hardcode-C-include-path-from-host.patch
+++ b/recipe/0011-Hardcode-C-include-path-from-host.patch
@@ -56,7 +56,7 @@ index 2304311..ed4ebc2 100644
 -      for (const auto& Arg : Args)
 -        cling::log() << "  " << Arg.second << "\n";
 -    }
-+    Args.addArgument("-cxx-isystem", std::string(::getenv("PREFIX")) + std::string("/include/c++/v1"));
++    Args.addArgument("-cxx-isystem", std::string(::getenv("CONDA_PREFIX")) + std::string("/include/c++/v1"));
    }
  
    static bool AddCxxPaths(llvm::StringRef PathStr, AdditionalArgList& Args,

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ source:
     - 0011-Hardcode-C-include-path-from-host.patch  # [osx]
 
 build:
-  number: 3
+  number: 4
   skip: true  # [win]
   # cross-python does not support pypy yet
   skip: true  # [build_platform != target_platform and python_impl == "pypy"]


### PR DESCRIPTION
I thought that this code path is only entered during build but it also needs to work at runtime.